### PR TITLE
fix a bug where origin is taken from options rather than opts

### DIFF
--- a/packages/maker.js/src/core/pdf.ts
+++ b/packages/maker.js/src/core/pdf.ts
@@ -43,7 +43,7 @@
         var left = -size.low[0];
         var offset: IPoint = [left, size.high[1]];
 
-        offset = point.add(offset, options.origin);
+        offset = point.add(offset, opts.origin);
 
         model.findChains(
             scaledModel,


### PR DESCRIPTION
options is an optional parameter which is used to extend the local opts variable. opts should be used in the code rather than options.